### PR TITLE
ApiClient - fix User-Agent header; don't send multiple values

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -223,7 +223,7 @@ class ApiClient
             'key' => $this->apiKey
         ], $httpParams);
 
-        $userAgent = implode(' ', $this->versionStrings);
+        $userAgent = implode(';', $this->versionStrings);
 
         $headers = [
             'Accept' => 'application/json',


### PR DESCRIPTION
The `User-Agent` HTTP request header does not follow the [rfc](https://tools.ietf.org/html/rfc2616.html#section-3.8) which defines that spaces are used to separate multiple values. See also https://github.com/elastic/beats/issues/14747 for example